### PR TITLE
adding virtualenv and tweaking config for Vagrant env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,21 @@ example/bin/pxe*
 *.vdi
 *.box
 packer_cache
+
+# # python giblets
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Environment / Unit test / coverage reports
+.tox
+.venv
+.passwdc

--- a/CI/README.md
+++ b/CI/README.md
@@ -1,0 +1,20 @@
+# Running Integration Tests
+
+
+## setup
+
+    virtualenv .venv
+    pip install -r requirements.txt
+
+## running the tests
+
+run Vagrant environment
+
+    cd ../example
+    vagrant up
+    vagrant ssh dev -c "sudo nf start"
+    cd ../CI
+
+run the tests
+
+    python run.py

--- a/CI/config/amqp.py
+++ b/CI/config/amqp.py
@@ -1,11 +1,11 @@
 from kombu import Exchange, Queue
 
-AMQP_URL = 'amqp://localhost'
+AMQP_URL = 'amqp://localhost:9091'
 
 # Task exchange queues
 EXCHANGE_TASK           = Exchange('on.task', type='topic')
-QUEUE_SEL_RESULT        = Queue('ipmi.command.sel.result', 
-                                EXCHANGE_TASK, 
+QUEUE_SEL_RESULT        = Queue('ipmi.command.sel.result',
+                                EXCHANGE_TASK,
                                 routing_key='ipmi.command.sel.result.*')
 QUEUE_SDR_RESULT        = Queue('ipmi.command.sdr.result',
                                 EXCHANGE_TASK,

--- a/CI/config/settings.py
+++ b/CI/config/settings.py
@@ -10,10 +10,10 @@ LOGLEVEL = 2
 LOGFMT = '%(asctime)s:%(name)s:%(levelname)s - %(message)s'
 
 HOST_IP = 'localhost'
-HOST_PORT = '8080'
+HOST_PORT = '9090'
 CRED_FILE = '.passwd'
 
-# Obfuscate credentials 
+# Obfuscate credentials
 def set_bmc_cred(user,password):
     u = b64encode(user)
     p = b64encode(password)
@@ -34,4 +34,3 @@ if isfile(CRED_FILE) is False:
         DEFAULT_BMC_USER = raw_input('BMC username: ')
         DEFAULT_BMC_PASS = getpass('BMC password: ')
     set_bmc_cred(DEFAULT_BMC_USER,DEFAULT_BMC_PASS)
-

--- a/CI/requirements.txt
+++ b/CI/requirements.txt
@@ -1,0 +1,6 @@
+amqp==1.4.8
+anyjson==0.3.3
+kombu==3.0.30
+logging==0.4.9.6
+proboscis==1.2.6.0
+requests==2.9.0

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
         target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
         target.vm.network "forwarded_port", guest: 8080, host: 9090
+        target.vm.network "forwarded_port", guest: 5672, host: 9091
 
         # If true, then any SSH connections made will enable agent forwarding.
         # Default value: false


### PR DESCRIPTION
hey @jlongever - I added a virtualenv, .gitignore, and a README for the CI directory based on your email. Not sure if you intended this to run against a vagrant instance, or in the vagrant instance - so I also included (and can remove) settings tweaks for Vagrant to both expose AMQP from it, and use that in the tests (ports 9090 and 9091 respectively - just arbitrarily picked)

Not all the tests are passing against my vagrant instance, but not surprising given you're expecting IPMI based catalogs and such in the system, which mine doesn't have.

Let me know if this is useful - pull request is against your branch, not RackHD, so merging this will include the changes into your branch only. Figured that was appropriate for a work in progress effort.

(redone against the correct branch...)
